### PR TITLE
Accomodate small change in data.table v1.11.0

### DIFF
--- a/R/report.R
+++ b/R/report.R
@@ -694,8 +694,8 @@ reportSNV <- function(parser_dir,tab_dir,report_dir="./"){
     
     dt<-fread(pepsummary_path,header=TRUE)
     setnames(dt,"index","Query") 
-    dt_var<-subset(dt,isSAP=="true")
-    dt_con<-subset(dt,isSAP=="false") 
+    dt_var<-subset(dt,isSAP==TRUE)
+    dt_con<-subset(dt,isSAP==FALSE) 
     
     dt_tab<-read.delim(tab_path,header=TRUE,stringsAsFactors=FALSE)
     setDT(dt_tab)


### PR DESCRIPTION
Hi Bo,
`fread` in data.table v1.110 (soon to be on CRAN) now recognizes "true" and "false" (all lower case) as a logical column automatically. So these two lines were resulting in empty results in dt_var, eventually ending up with this error :
```
Stage 4. HTML-based report generation.
None of SNV were identified!
Error in 1:dim(data)[1] : argument of length 0
Calls: easyRun -> reportGear -> .spplot
Execution halted
```
Hope it's ok to fix.   Thanks and best, Matt