### PR TITLE
Fix a minor bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,12 +7,12 @@ Description: This package provides functions for construction of customized
     searching, post-processing and report generation. This kind of customized
     protein database includes both the reference database (such as Refseq or
     ENSEMBL) and the novel peptide sequences form RNA-Seq data.
-Version: 1.15.1
-Date: 2019-06-21
+Version: 1.15.2
+Date: 2020-08-26
 Author: Shaohang Xu, Bo Wen
 Maintainer: Bo Wen <wenbostar@gmail.com>, Shaohang Xu <xsh.skye@gmail.com>
 Depends:
-    R (>= 3.5.0),
+    R (>= 4.0.0),
     IRanges,
     GenomicRanges,
     Biostrings (>= 2.26.3),
@@ -54,4 +54,3 @@ biocViews: Proteomics,
     ReportWriting,
     RNASeq,
     Sequencing
-RoxygenNote: 6.1.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,4 @@
-importFrom(data.table,"%between%", "%chin%", "%like%", ":=",  as.data.table, between, chgroup, chmatch, chorder, CJ, copy, data.table, dcast, dcast.data.table, foverlaps,fread, haskey, key, "key<-", key2, last, like,melt, set, set2key, set2keyv, setattr, setDF, setDT, setkey, setkeyv, setnames,  setorder, setorderv)
+importFrom(data.table,"%between%", "%chin%", "%like%", ":=",  as.data.table, between, chgroup, chmatch, chorder, CJ, copy, data.table, dcast, dcast.data.table, foverlaps,fread, haskey, key, "key<-", last, like,melt, set, setattr, setDF, setDT, setkey, setkeyv, setnames,  setorder, setorderv)
 importFrom("grDevices", "colorRampPalette", "dev.off", "pdf", "png",
              "rainbow")
 importFrom("graphics", "abline", "axTicks", "axis", "barplot", "box",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Version 1.15.2
+
+o set2key, set2keyv, and key2 of data.table were deprecated and had been removed.
+
 Version 1.15.1
 
 o Implementation for the protein database construction from fusion events(buildFusionProteinDB). Currently, this function only supports the calling result from STAR-fusion.


### PR DESCRIPTION
set2key, set2keyv, and key2 of data.table were deprecated and had been removed.